### PR TITLE
Ignore empty filename from content-disposition

### DIFF
--- a/lib/paperclip/io_adapters/uri_adapter.rb
+++ b/lib/paperclip/io_adapters/uri_adapter.rb
@@ -31,7 +31,7 @@ module Paperclip
       if @content.meta.has_key?("content-disposition")
         matches = @content.meta["content-disposition"].
           match(/filename="([^"]*)"/)
-        matches[1] if matches
+        matches[1].presence if matches
       end
     end
 


### PR DESCRIPTION
Added the same commit that Mike Burns made to correct this.
https://github.com/thoughtbot/paperclip/pull/2437/files

Also, see this issue for related details:
https://github.com/thoughtbot/paperclip/issues/2563